### PR TITLE
Add tool publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,4 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Generate version
         id: gen_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: "Publish"
+
+on:
+  push:
+    tags:
+      - "v**.**.**" # Semantic Versioning like "v1.22.3"
+      - "v**.**.**-**" # Prerelease Semantic Versioning like "v1.22.3-rc0004"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Generate version
+        id: gen_version
+        # because tags in GITHUB cannot be something like "1.22.3" we have to prepend a "v" for version tags
+        # but because a "v" is prepended, we have to remove that again to be able to use the version tag as the version for packaging and pushing the NuGet-package
+        # the "//v/" basically tells that every "v" is replaced by an empty string. c.f.: https://stackoverflow.com/a/67290085/8242470
+        # using the approach to generate the version in another job for others to use works better than doing that in a global variable, c.f.: https://github.com/orgs/community/discussions/45488
+        run: echo "VERSION=${GITHUB_REF_NAME//v/}" >> $GITHUB_OUTPUT
+
+      - name: Pack
+        env:
+          VERSION: ${{ steps.gen_version.outputs.VERSION }}
+        run: dotnet pack ./src/sln-items-sync.csproj --configuration Release /p:Version=${{ env.VERSION }}
+
+      - name: Push to Nuget.org
+        env:
+          VERSION: ${{ steps.gen_version.outputs.VERSION }}
+        run: dotnet nuget push ./src/bin/Release/sln-items-sync.${{ env.VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -2,14 +2,31 @@
 
 Run this against a `.sln` file with a list of paths and it will update the solution items to match
 
-Usage
-
-```
-dotnet run --project src/sln-items-sync.csproj --solution sln-items-sync.sln README.md .github
-```
+## Usage
 
 Files will be added if missing.
 
 Folders will be recursively added.
 
 `SolutionItems` folder will be created and populated if missing.
+
+### Local installation
+
+```bash
+# if you don't have a manifest file yet
+dotnet new tool-manifest
+
+dotnet tool install --local sln-items-sync
+
+# run the tool
+dotnet sln-items-sync --solution YourSolution.sln README.md .github
+```
+
+### Global installation
+
+```bash
+dotnet tool install --global sln-items-sync
+
+# run the tool
+sln-items-sync --solution YourSolution.sln README.md .github
+```

--- a/src/sln-items-sync.csproj
+++ b/src/sln-items-sync.csproj
@@ -9,6 +9,22 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageId>sln-items-sync</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>sln-items-sync</ToolCommandName>
+
+    <Authors>Tim Abell and Contributors</Authors>
+    <Description>
+      Run this against a .sln file with a list of paths and it will update the solution items to match
+    </Description>
+    <PackageProjectUrl>https://github.com/timabell/sln-items-sync</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/timabell/sln-items-sync</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>dotnet;CLI;Tool;Solution;Sync;Items</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="SlnEditor" Version="6.1.0" />

--- a/src/sln-items-sync.csproj
+++ b/src/sln-items-sync.csproj
@@ -5,8 +5,6 @@
     <RootNamespace>sln_items_sync</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Closes #4  
  
This configures the main-project in a way that it can be published as a .NET CLI Tool. Which then can be used using the .NET Tool toolchain (lol) (see the updated README for more information).  
This way users can easily install and use your tool without needing to download any files with proper versioning.  
  
To be able to publish you have to do the following as an author:
1. Sign In to nuget.org using your Microsoft Account
2. When signed in, go to https://www.nuget.org/account/apikeys and create a new key. The "Key Name" can be anything but for the "Glob Pattern" you have to specify the package name(s) that you want this key be for. For this project that should be `sln-items-sync.*`
3. This will then give you your API-Key which can only copy **once**
4. Use this API-Key and create a new "Repository secret" under https://github.com/timabell/sln-items-sync/settings/secrets/actions with the name `NUGET_API_KEY` (see new `publish.yml`) file

This should be enough to be able to publish your tool to nuget.org when pushing a version tag (such as `v1.22.333` or as a preview `v1.22.333-preview1`)

Let me know if you need anything to be changed :)